### PR TITLE
refactor(test): Add Unit Tests for EmailService and RabbitMQ Consumer

### DIFF
--- a/test/consumer.test.js
+++ b/test/consumer.test.js
@@ -1,0 +1,72 @@
+jest.mock("amqplib");
+jest.mock("../src/services/email.service");
+
+const amqp = require("amqplib");
+const EmailService = require("../src/services/email.service");
+const consume = require("../src/rabbitmq/consumer");
+
+describe("RabbitMQ Consumer", () => {
+    let channelMock;
+    let connectMock;
+
+    beforeEach(() => {
+        channelMock = {
+            assertExchange: jest.fn(),
+            assertQueue: jest.fn().mockResolvedValue({ queue: "email_queue" }),
+            bindQueue: jest.fn(),
+            consume: jest.fn(),
+            ack: jest.fn(),
+            nack: jest.fn(),
+        };
+
+        connectMock = {
+            createChannel: jest.fn().mockResolvedValue(channelMock)
+        };
+
+        amqp.connect.mockResolvedValue(connectMock);
+    });
+
+    test("Debe consumir mensajes y llamar EmailService.sendReportEmail", async () => {
+        await consume();
+
+        const fakeMsg = {
+            content: Buffer.from(JSON.stringify({
+                to: "test@example.com",
+                userName: "daniel",
+                reportName: "Reporte X",
+                generatedAt: new Date().toISOString()
+            }))
+        };
+
+        const consumeCallback = channelMock.consume.mock.calls[0][1];
+
+        EmailService.sendReportEmail.mockResolvedValue(true);
+
+        await consumeCallback(fakeMsg);
+
+        expect(EmailService.sendReportEmail).toHaveBeenCalledTimes(1);
+        expect(channelMock.ack).toHaveBeenCalledWith(fakeMsg);
+    });
+
+    test("Debe llamar nack si hay error enviando el correo", async () => {
+        await consume();
+
+        const fakeMsg = {
+            content: Buffer.from(JSON.stringify({ test: true }))
+        };
+
+        const cb = channelMock.consume.mock.calls[0][1];
+
+        // 🟣 Evita que el test imprima el console.error
+        const consoleErrorMock = jest.spyOn(console, "error").mockImplementation(() => { });
+
+        EmailService.sendReportEmail.mockRejectedValue(new Error("Error SMTP"));
+
+        await cb(fakeMsg);
+
+        expect(channelMock.nack).toHaveBeenCalledWith(fakeMsg, false, false);
+
+        // 🟣 Restaurar consola original
+        consoleErrorMock.mockRestore();
+    });
+});

--- a/test/email.service.test.js
+++ b/test/email.service.test.js
@@ -1,0 +1,39 @@
+// 1. Mockear nodemailer ANTES de importar el servicio
+jest.mock("nodemailer", () => ({
+  createTransport: jest.fn()
+}));
+
+const nodemailer = require("nodemailer");
+
+// Mock del sendMail
+const sendMailMock = jest.fn().mockResolvedValue(true);
+
+// Configurar el mock de createTransport
+nodemailer.createTransport.mockReturnValue({
+  sendMail: sendMailMock
+});
+
+// 2. Ahora sí importar el servicio (ya mockeado)
+const EmailService = require("../src/services/email.service");
+
+describe("EmailService.sendReportEmail", () => {
+
+  test("Debe enviar un correo con los datos correctos", async () => {
+    const payload = {
+      to: "test@example.com",
+      userName: "danna",
+      reportName: "Reporte de Prueba",
+      generatedAt: new Date().toISOString()
+    };
+
+    await EmailService.sendReportEmail(payload);
+
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    expect(sendMailMock).toHaveBeenCalledWith({
+      from: process.env.EMAIL_USER,
+      to: "test@example.com",
+      subject: "SYX | Reporte de Prueba",
+      text: expect.stringContaining("Reporte generado por: danna")
+    });
+  });
+});


### PR DESCRIPTION
## Description

This Pull Request adds the first set of **unit tests for the email microservice**, focusing on the core domain behavior of:

- `EmailService.sendReportEmail`
- `consume()` from `rabbitmq/consumer.js`

These tests ensure that the email logic and message-processing workflow behave correctly while keeping all infrastructure fully mocked (RabbitMQ, Nodemailer).

No production logic was modified — only tests were added.

## Changes include 
### **1. EmailService Tests**
Added `email.service.test.js` to validate:
- correct structure of the email
- correct parameters passed to `sendMail()`
- proper usage of `userName`, `to`, `reportName`, and `generatedAt`
- nodemailer fully mocked (no real emails sent)

### **2. RabbitMQ Consumer Tests**
Added `consumer.test.js` to validate:
- The consumer correctly parses events
- Calls `EmailService.sendReportEmail`
- ACKs the message when successful
- NACKs the message when EmailService throws an error

### **3. Test Configuration**
- Jest mocks for both `nodemailer` and `amqplib`
- Isolated test environment
- No external services required

## Expected bahavior

These tests ensure:
- Email logic works independently of infrastructure
- Failures in sending emails are correctly handled
- The consumer behaves safely (ack / nack)
- Future refactors won’t break the notification system

This strengthens service reliability and improves development velocity.

### Closes 

closes: #4 

